### PR TITLE
removed msg from cmake

### DIFF
--- a/vectornav_msgs/CMakeLists.txt
+++ b/vectornav_msgs/CMakeLists.txt
@@ -24,8 +24,6 @@ find_package(rosidl_default_generators REQUIRED)
 file(GLOB msg_sources RELATIVE ${PROJECT_SOURCE_DIR} msg/*.msg)
 file(GLOB act_sources RELATIVE ${PROJECT_SOURCE_DIR} action/*.action)
 
-message("Grabbing messages ${act_sources}")
-
 
 rosidl_generate_interfaces(${PROJECT_NAME}
   ${msg_sources}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To remove this msg everytime we build

```bash
Starting >>> teleop_twist_joy
Finished <<< yolov8_msgs [2min 6s]                                                                                                                              
Starting >>> camera_info_manager
--- stderr: vectornav_msgs                                                                                                                                         
Grabbing messages action/MagCal.action
---
Finished <<< vectornav_msgs [2min 30s]
Starting >>> ds4_driver
```


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):